### PR TITLE
Fix PostmarketOS build

### DIFF
--- a/.github/workflows/postmarketos.yml
+++ b/.github/workflows/postmarketos.yml
@@ -97,8 +97,9 @@ jobs:
           pkgrel=$pkgrel
           pkgdesc="Yukigram (Telegram Desktop fork) messaging app"
           depends="\$depends ada"
-          source="\${source/https:*.tar.gz/yukigram.tar.gz}"
+          source="\${source//https:*-full.tar.gz/yukigram.tar.gz}"
           builddir="\$srcdir/$REPO_NAME"
+          unset maintainer
           EOF
           tar -czf pmaports/temp/yukigram/yukigram.tar.gz "$REPO_NAME"
 


### PR DESCRIPTION
TDesktop now requires an out-of-tree TDLib build for E2E support. This broke the src replacement.